### PR TITLE
Fetch light status before applying changes

### DIFF
--- a/actions/ElgatoKeyLight/Core.py
+++ b/actions/ElgatoKeyLight/Core.py
@@ -5,7 +5,6 @@ import os
 import gi
 import threading
 import time
-import json
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
@@ -174,7 +173,7 @@ class Core(ActionBase):
         url = f"http://{ip_address}:9123/elgato/lights"
         try:
             r = requests.get(url)
-            return json.loads(r.text)
+            return r.json()
         except:
             return "Failed to get lights"
 


### PR DESCRIPTION
We now fetch the current status of the lamp before applying any changes. This makes the behavior of the buttons more predictable. Especially if you change the state of the lamp with other apps while using the StreamController

Closes #9